### PR TITLE
Handle Infinity in Plots Correctly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PersistenceDiagrams"
 uuid = "90b4794c-894b-4756-a0f8-5efeb5ddf7ae"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/plotsrecipes.jl
+++ b/src/plotsrecipes.jl
@@ -68,7 +68,7 @@ end
     x, y
 end
 
-function limits(diags)
+function limits(diags, infinity=nothing)
     xs = map.(birth, diags)
     ys = map.(death, diags)
 
@@ -77,10 +77,12 @@ function limits(diags)
     t_hi = reduce(max, t for t in Iterators.flatten((xs..., ys...)) if t < Inf; init=0.0)
 
     threshes = filter(isfinite, threshold.(diags))
-    if !isempty(threshes)
-        infinity = maximum(threshes)
-    else
-        infinity = t_hi * 1.25
+    if isnothing(infinity)
+        if !isempty(threshes)
+            infinity = maximum(threshes)
+        else
+            infinity = t_hi * 1.25
+        end
     end
     if any(!isfinite, Iterators.flatten(ys))
         t_hi = infinity
@@ -96,7 +98,7 @@ end
 
 function setup_diagram_plot!(d, diags)
     set_default!(d, :persistence, false)
-    t_lo, t_hi, infinity = limits(diags)
+    t_lo, t_hi, infinity = limits(diags, get(d, :infinity, nothing))
     # Zero persistence line messes up the limits, so we attempt to reset them here.
     gap = (t_hi - t_lo) * 0.05
     if gap > 0


### PR DESCRIPTION
Setting `infinity` moved the line, but didn't set plot limits correctly.