### PR TITLE
Interval Input Types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PersistenceDiagrams"
 uuid = "90b4794c-894b-4756-a0f8-5efeb5ddf7ae"
 authors = ["mtsch <matijacufar@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/diagrams.jl
+++ b/src/diagrams.jl
@@ -11,10 +11,10 @@ struct PersistenceInterval{R}
     representative::R
 end
 
-function PersistenceInterval{Nothing}(birth::Real, death::Real)
+function PersistenceInterval{Nothing}(birth, death)
     return PersistenceInterval{Nothing}(Float64(birth), Float64(death), nothing)
 end
-function PersistenceInterval(birth::Real, death::Real, rep::R=nothing) where R
+function PersistenceInterval(birth, death, rep::R=nothing) where R
     return PersistenceInterval{R}(Float64(birth), Float64(death), rep)
 end
 function PersistenceInterval(t::Tuple{<:Any, <:Any}, rep=nothing)


### PR DESCRIPTION
Remove the `<:Real` restriction from the `PersistenceInterval` constructor. This allow use with color types.