### PR TITLE
Computing distances between two empty PersistenceDiagrams

### DIFF
--- a/src/matching.jl
+++ b/src/matching.jl
@@ -406,7 +406,7 @@ function (::Bottleneck)(left::PersistenceDiagram, right::PersistenceDiagram; mat
         if matching
             return Matching(left, right, 0, Pair{Int,Int}[], true)
         else
-            return 0
+            return 0.0
         end
     end 
 

--- a/src/matching.jl
+++ b/src/matching.jl
@@ -507,7 +507,7 @@ function (w::Wasserstein)(
         if matching
             return Matching(left, right, 0, Pair{Int,Int}[], false)
         else
-            return 0
+            return 0.0
         end
     end 
 

--- a/src/matching.jl
+++ b/src/matching.jl
@@ -402,6 +402,14 @@ function (::Bottleneck)(left::PersistenceDiagram, right::PersistenceDiagram; mat
         end
     end
 
+    if length(left) == 0 & length(right) == 0 
+        if matching
+            return Matching(left, right, 0, Pair{Int,Int}[], true)
+        else
+            return 0
+        end
+    end 
+
     graph = BottleneckGraph(left, right)
     edges = graph.edges
 
@@ -494,6 +502,15 @@ end
 function (w::Wasserstein)(
     left::PersistenceDiagram, right::PersistenceDiagram; matching=false
 )
+
+    if length(left) == 0 & length(right) == 0 
+        if matching
+            return Matching(left, right, 0, Pair{Int,Int}[], false)
+        else
+            return 0
+        end
+    end 
+
     if count(!isfinite, left) == count(!isfinite, right)
         adj = _adjacency_matrix(right, left, w.q)
         match = collect(i => j for (i, j) in enumerate(hungarian(adj)[1]))

--- a/test/matching.jl
+++ b/test/matching.jl
@@ -79,6 +79,14 @@ end
     @test weight(Wasserstein(), diag1, diag1) ≡ 0.0
 end
 
+@testset "Empty diagrams" begin
+    diag = PersistenceDiagram([])
+
+    @test Wasserstein()(diag,diag; matching = false) ≡ 0
+    @test Bottleneck()(diag,diag; matching = false) ≡ 0
+
+end
+
 @testset "Infinite intervals" begin
     diag1 = PersistenceDiagram([(1, 2), (5, 8), (1, Inf)])
     diag2 = PersistenceDiagram([(1, 2), (3, 4), (5, 10)])

--- a/test/matching.jl
+++ b/test/matching.jl
@@ -82,8 +82,8 @@ end
 @testset "Empty diagrams" begin
     diag = PersistenceDiagram([])
 
-    @test Wasserstein()(diag,diag; matching = false) ≡ 0
-    @test Bottleneck()(diag,diag; matching = false) ≡ 0
+    @test Wasserstein()(diag,diag; matching = false) ≡ 0.0
+    @test Bottleneck()(diag,diag; matching = false) ≡ 0.0
 
 end
 


### PR DESCRIPTION
A distance (either Wasserstein or Bottleneck) between two empty PersistenceDiagrams should return zero. (Empty diagrams contain trivially the "diagonal" in the birth-death graph, and distance between the diagram and itself should be zero.)

Before this change, the code produces an error when applying either `hungarian` or `_hopcroft_karp` algorithms in `matching.jl`, and the two errors are different.

The pull request performs a simple test at the beginning of `Bottleneck()` and `Wasserstein()` functions and returns the distance zero or a zero `Matching`.

The pull additionally adds a unit test group for this issue.