### PR TITLE
Fixed matching

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,7 +12,7 @@ jobs:
           import Pkg
           name = "CompatHelper"
           uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
-          version = "2"
+          version = "3"
           Pkg.add(; name, uuid, version)
         shell: julia --color=yes {0}
       - name: "Run CompatHelper"

--- a/src/matching.jl
+++ b/src/matching.jl
@@ -85,11 +85,11 @@ function matching(match::Matching; bottleneck=match.bottleneck)
         elseif i ≤ n
             # left is matched to diagonal
             l = match.left[i]
-            push!(result, match.left[i] => PersistenceInterval((birth(l)+death(l)), (birth(l)+death(l))))
+            push!(result, match.left[i] => PersistenceInterval((birth(l)+death(l))/2, (birth(l)+death(l))/2))
         elseif j ≤ m
             # right is matched to diagonal
             r = match.right[j]
-            push!(result, PersistenceInterval((birth(r)+death(r)), (birth(r)+death(r))) => r)
+            push!(result, PersistenceInterval((birth(r)+death(r))/2, (birth(r)+death(r))/2) => r)
         end
     end
     sort!(result)

--- a/src/matching.jl
+++ b/src/matching.jl
@@ -159,10 +159,14 @@ function _adjacency_matrix(left, right, power=1)
         adj[j, i] = abs(birth(left[i]) - birth(right[j]))
     end
     for i in 1:n
-        adj[i + m, i] = persistence(left[i])
+        l = left[i]
+        d = (birth(l)+death(l))/2
+        adj[i + m, i] = max(abs(birth(l) - d), abs(death(l) - d))
     end
     for j in 1:m
-        adj[j, j + n] = persistence(right[j])
+        r = right[j]
+        d = (birth(r)+death(r))/2
+        adj[j, j + n] = max(abs(birth(r) - d), abs(death(r) - d))
     end
     adj[(m + 1):(m + n), (n + 1):(n + m)] .= 0.0
 


### PR DESCRIPTION
In the current version, when you want to do a matching, dummy points on the x=y line are created on the coordinates: [birth, birth] but they should be: [(birth+death)/2, (birth+death)/2] i.e. the point on the perpendicular line.

Mathematically, if we only use Wasserstein of order 1, the results are the same but they aren't in the higher orders.
The code below fixes the problem.

P.S. sorry if my explanation wasn't clear this is the first pull request I am making. Please ask me if it wasn't clear.

Thanks.